### PR TITLE
Remove file touch workaround in write()

### DIFF
--- a/build/imagefs.js
+++ b/build/imagefs.js
@@ -85,9 +85,7 @@ exports.read = function(definition) {
 
 exports.write = function(definition, stream) {
   return driver.interact(definition.image, definition.partition).then(function(fat) {
-    return fat.openAsync(definition.path, 'w').then(fat.closeAsync).then(function() {
-      return stream.pipe(fat.createWriteStream(definition.path));
-    });
+    return stream.pipe(fat.createWriteStream(definition.path));
   });
 };
 

--- a/lib/imagefs.coffee
+++ b/lib/imagefs.coffee
@@ -77,12 +77,7 @@ exports.read = (definition) ->
 ###
 exports.write = (definition, stream) ->
 	driver.interact(definition.image, definition.partition).then (fat) ->
-
-		# "touch" the file before writing to it to make sure it exists
-		# otherwise, the write operation is ignored and no error is thrown.
-		fat.openAsync(definition.path, 'w').then(fat.closeAsync).then ->
-
-			return stream.pipe(fat.createWriteStream(definition.path))
+		return stream.pipe(fat.createWriteStream(definition.path))
 
 ###*
 # @summary Copy a device file


### PR DESCRIPTION
This is fixed by using the latest edison image.