### PR TITLE
Make sure to close driver file descriptors

### DIFF
--- a/build/driver.js
+++ b/build/driver.js
@@ -91,6 +91,9 @@ exports.createDriverFromFile = function(file, offset, size) {
     var driver, fat;
     driver = exports.getDriver(fd, offset, size);
     fat = fatfs.createFileSystem(driver);
+    fat.closeDriver = function() {
+      return fs.closeAsync(fd);
+    };
     return Promise.fromNode(function(callback) {
       fat.on('error', callback);
       return fat.on('ready', function() {

--- a/build/imagefs.js
+++ b/build/imagefs.js
@@ -58,7 +58,7 @@ driver = require('./driver');
 
 exports.read = function(definition) {
   return driver.interact(definition.image, definition.partition).then(function(fat) {
-    return fat.createReadStream(definition.path);
+    return fat.createReadStream(definition.path).on('end', fat.closeDriver);
   });
 };
 
@@ -87,7 +87,7 @@ exports.read = function(definition) {
 
 exports.write = function(definition, stream) {
   return driver.interact(definition.image, definition.partition).then(function(fat) {
-    return stream.pipe(fat.createWriteStream(definition.path));
+    return stream.pipe(fat.createWriteStream(definition.path)).on('close', fat.closeDriver);
   });
 };
 

--- a/lib/driver.coffee
+++ b/lib/driver.coffee
@@ -77,6 +77,11 @@ exports.createDriverFromFile = (file, offset, size) ->
 		driver = exports.getDriver(fd, offset, size)
 		fat = fatfs.createFileSystem(driver)
 
+		# Not closing it might cause EPERM errors
+		# when unlinking the file
+		fat.closeDriver = ->
+			return fs.closeAsync(fd)
+
 		Promise.fromNode (callback) ->
 			fat.on('error', callback)
 			fat.on 'ready', ->

--- a/lib/imagefs.coffee
+++ b/lib/imagefs.coffee
@@ -54,6 +54,7 @@ driver = require('./driver')
 exports.read = (definition) ->
 	driver.interact(definition.image, definition.partition).then (fat) ->
 		return fat.createReadStream(definition.path)
+			.on('end', fat.closeDriver)
 
 ###*
 # @summary Write to a device file
@@ -79,6 +80,7 @@ exports.read = (definition) ->
 exports.write = (definition, stream) ->
 	driver.interact(definition.image, definition.partition).then (fat) ->
 		return stream.pipe(fat.createWriteStream(definition.path))
+			.on('close', fat.closeDriver)
 
 ###*
 # @summary Copy a device file


### PR DESCRIPTION
Not doing this causes open file descriptors to remain open on files that
were modified by this module. Attempts to unlink those files causes
EPERM errors.